### PR TITLE
Add PDF CV export endpoint

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -54,9 +54,10 @@ export const Navbar = () => {
       <div className="flex items-center gap-2 sm:gap-4">
         {/* <Link href="/projects" className={"transition-color hover:text-mint-11"}>Projects</Link> */}
         <Link href="/blog" className="transition-color hover:text-mint-11">Blog</Link>
+        {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
         <a
-          href='/resume.pdf'
-          download='makenna-smutz_resume' className="transition-color hover:text-mint-11"
+          href='/api/cv'
+          className="transition-color hover:text-mint-11"
         >
           CV
         </a>

--- a/pages/api/cv.ts
+++ b/pages/api/cv.ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { client } from '@/utils/graphql-client'
+import { ExperiencesDocument, ExperiencesQuery } from '@/utils/graphql-generated'
+import { generateResumePdf } from '@/utils/pdf-resume'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { data } = await client.query<ExperiencesQuery>({
+    query: ExperiencesDocument,
+  })
+
+  const pdf = generateResumePdf(data.experiences)
+  res.setHeader('Content-Type', 'application/pdf')
+  res.setHeader('Content-Disposition', 'inline; filename="cv.pdf"')
+  res.status(200).send(pdf)
+}

--- a/pages/cv.tsx
+++ b/pages/cv.tsx
@@ -1,0 +1,17 @@
+import Head from 'next/head'
+
+const CvPreview = () => {
+  return (
+    <>
+      <Head>
+        <title>CV Preview</title>
+        <meta name='robots' content='noindex' />
+      </Head>
+      <section className='mt-24 max-w-screen-lg mx-auto flex justify-center'>
+        <object data='/api/cv' type='application/pdf' className='w-full h-[90vh]' />
+      </section>
+    </>
+  )
+}
+
+export default CvPreview

--- a/utils/pdf-resume.ts
+++ b/utils/pdf-resume.ts
@@ -1,23 +1,45 @@
 import { ExperiencesQuery } from './graphql-generated'
 
 export function generateResumePdf(experiences: ExperiencesQuery['experiences']): Buffer {
-  const header = '%PDF-1.4\n'
   const escape = (text: string) => text.replace(/[()\\]/g, '\\$&')
+  const header = '%PDF-1.4\n'
+
+  const title = 'Makenna Smutz'
+  const contact = 'https://makenna.dev'
+
   const lines = experiences.map(
-    (e) => `${e.jobTitle} @ ${e.company} (${e.dateRange})`
+    (e) => `- ${e.jobTitle} @ ${e.company} (${e.dateRange})`
   )
 
-  const contentLines = lines
-    .map((line) => `(${escape(line)}) Tj\nT* `)
-    .join('')
-  const contentStream = `BT\n/F1 12 Tf\n50 780 Td\n${contentLines}ET`
+  const lineHeight = 18
+  const startY = 720
+
+  const contentParts = [
+    'BT',
+    '/F1 20 Tf',
+    '50 780 Td',
+    `(${escape(title)}) Tj`,
+    '/F1 12 Tf',
+    `0 -24 Td`,
+    `(${escape(contact)}) Tj`,
+    `50 ${startY} Td`,
+    `${lineHeight} TL`
+  ]
+
+  lines.forEach((line, idx) => {
+    if (idx > 0) contentParts.push('T*')
+    contentParts.push(`(${escape(line)}) Tj`)
+  })
+  contentParts.push('ET')
+
+  const contentStream = contentParts.join('\n')
 
   const objects = [
     '1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n',
     '2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n',
     '3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n',
     `4 0 obj\n<< /Length ${contentStream.length} >>\nstream\n${contentStream}\nendstream\nendobj\n`,
-    '5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n',
+    '5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n'
   ]
 
   let offset = header.length

--- a/utils/pdf-resume.ts
+++ b/utils/pdf-resume.ts
@@ -9,11 +9,12 @@ export function generateResumePdf(
   const title = 'Makenna Smutz'
   const contact = 'https://makenna.dev'
 
+  const bullet = String.fromCharCode(149)
   const bodyLines: string[] = []
   experiences.forEach((exp) => {
     bodyLines.push(`${exp.jobTitle} @ ${exp.company} (${exp.dateRange})`)
     exp.responsibilities.forEach((resp) => {
-      bodyLines.push(`  • ${resp}`)
+      bodyLines.push(`  ${bullet} ${resp}`)
     })
     bodyLines.push('')
   })
@@ -24,12 +25,14 @@ export function generateResumePdf(
   const contentParts = [
     'BT',
     '/F1 24 Tf',
-    '50 780 Td',
+    '0.067 0.094 0.153 rg',
+    `1 0 0 1 50 780 Tm`,
     `(${escape(title)}) Tj`,
     '/F1 12 Tf',
-    '0 -18 Td',
+    '0.216 0.255 0.318 rg',
+    `1 0 0 1 50 762 Tm`,
     `(${escape(contact)}) Tj`,
-    `50 ${startY} Td`,
+    `1 0 0 1 50 ${startY} Tm`,
     `${lineHeight} TL`
   ]
 
@@ -66,5 +69,5 @@ export function generateResumePdf(
   pdf += 'trailer\n<< /Root 1 0 R /Size ' + (objects.length + 1) + ' >>\n'
   pdf += 'startxref\n' + xrefOffset + '\n%%EOF'
 
-  return Buffer.from(pdf)
+  return Buffer.from(pdf, 'binary')
 }

--- a/utils/pdf-resume.ts
+++ b/utils/pdf-resume.ts
@@ -1,0 +1,41 @@
+import { ExperiencesQuery } from './graphql-generated'
+
+export function generateResumePdf(experiences: ExperiencesQuery['experiences']): Buffer {
+  const header = '%PDF-1.4\n'
+  const escape = (text: string) => text.replace(/[()\\]/g, '\\$&')
+  const lines = experiences.map(
+    (e) => `${e.jobTitle} @ ${e.company} (${e.dateRange})`
+  )
+
+  const contentLines = lines
+    .map((line) => `(${escape(line)}) Tj\nT* `)
+    .join('')
+  const contentStream = `BT\n/F1 12 Tf\n50 780 Td\n${contentLines}ET`
+
+  const objects = [
+    '1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n',
+    '2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n',
+    '3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n',
+    `4 0 obj\n<< /Length ${contentStream.length} >>\nstream\n${contentStream}\nendstream\nendobj\n`,
+    '5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n',
+  ]
+
+  let offset = header.length
+  const offsets = [0]
+  for (const obj of objects) {
+    offsets.push(offset)
+    offset += obj.length
+  }
+
+  let pdf = header + objects.join('')
+  const xrefOffset = pdf.length
+  pdf += 'xref\n0 ' + (objects.length + 1) + '\n'
+  pdf += '0000000000 65535 f \n'
+  for (let i = 1; i < offsets.length; i++) {
+    pdf += offsets[i].toString().padStart(10, '0') + ' 00000 n\n'
+  }
+  pdf += 'trailer\n<< /Root 1 0 R /Size ' + (objects.length + 1) + ' >>\n'
+  pdf += 'startxref\n' + xrefOffset + '\n%%EOF'
+
+  return Buffer.from(pdf)
+}

--- a/utils/pdf-resume.ts
+++ b/utils/pdf-resume.ts
@@ -1,32 +1,39 @@
 import { ExperiencesQuery } from './graphql-generated'
 
-export function generateResumePdf(experiences: ExperiencesQuery['experiences']): Buffer {
+export function generateResumePdf(
+  experiences: ExperiencesQuery['experiences']
+): Buffer {
   const escape = (text: string) => text.replace(/[()\\]/g, '\\$&')
   const header = '%PDF-1.4\n'
 
   const title = 'Makenna Smutz'
   const contact = 'https://makenna.dev'
 
-  const lines = experiences.map(
-    (e) => `- ${e.jobTitle} @ ${e.company} (${e.dateRange})`
-  )
+  const bodyLines: string[] = []
+  experiences.forEach((exp) => {
+    bodyLines.push(`${exp.jobTitle} @ ${exp.company} (${exp.dateRange})`)
+    exp.responsibilities.forEach((resp) => {
+      bodyLines.push(`  • ${resp}`)
+    })
+    bodyLines.push('')
+  })
 
-  const lineHeight = 18
+  const lineHeight = 14
   const startY = 720
 
   const contentParts = [
     'BT',
-    '/F1 20 Tf',
+    '/F1 24 Tf',
     '50 780 Td',
     `(${escape(title)}) Tj`,
     '/F1 12 Tf',
-    `0 -24 Td`,
+    '0 -18 Td',
     `(${escape(contact)}) Tj`,
     `50 ${startY} Td`,
     `${lineHeight} TL`
   ]
 
-  lines.forEach((line, idx) => {
+  bodyLines.forEach((line, idx) => {
     if (idx > 0) contentParts.push('T*')
     contentParts.push(`(${escape(line)}) Tj`)
   })


### PR DESCRIPTION
## Summary
- generate PDF CV from experience data
- expose endpoint to fetch the CV
- add preview page for development
- hook the Navbar CV link to the endpoint

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685ca2f3b314832fbdd17d765f9433de